### PR TITLE
Sending data to endpoint and remove integrated HTML templates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Downloading the Image From Docker Registry
-FROM test_app
+FROM python:3.8
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM python:3.8
 WORKDIR /app
 
 # Install app dependencies files
-#COPY requirements.txt ./
-#RUN pip3 install -r requirements.txt
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
 
 # Bundle app source
 COPY . .
 
-EXPOSE 5000
-CMD [ "flask", "run","--host","0.0.0.0","--port","5000"]
+EXPOSE 8000
+CMD [ "flask", "run","--host","0.0.0.0","--port","8000"]

--- a/app.py
+++ b/app.py
@@ -3,33 +3,29 @@
 import os
 import json
 from pathlib import Path
-from flask import Flask, render_template
+from flask import Flask
+
+# Importing Modules
+import helper_functions as f
 
 app = Flask(__name__) #creating Flask class object
 title='Quotation'
 
 @app.route('/') #decorator defines the
 @app.route('/home')
-@app.route('/base')
 @app.route('/index')
 @app.route('/homepage')
 def home():
     '''Hmme page for the quotation-app'''
     categories = [Path(file).stem for file in os.listdir("db")]
-    return render_template('home.html', categories=categories, title=title)
-
-def read_quotations_from_file(path):
-    with open(path, "r") as file:
-        quotations = json.load(file)
-    return quotations
+    return categories
 
 @app.route('/<category>_quotes.json')
 def quotes(category):
     '''Function return the quotes'''
     path = f'db/{category}.json'
-    quotations = read_quotations_from_file(path)
-    return render_template("quotes.html", category=category.upper(), 
-                            quotations=quotations, title=f'{category} quotes')
+    quotations = f.read_quotations_from_file(path)
+    return quotations
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -13,8 +13,6 @@ title='Quotation'
 
 @app.route('/') #decorator defines the
 @app.route('/home')
-@app.route('/index')
-@app.route('/homepage')
 def home():
     '''Hmme page for the quotation-app'''
     categories = [Path(file).stem for file in os.listdir("db")]

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ title='Quotation'
 def home():
     '''Hmme page for the quotation-app'''
     categories = [Path(file).stem for file in os.listdir("db")]
-    return categories
+    return {"categories": categories}
 
 @app.route('/<category>_quotes.json')
 def quotes(category):

--- a/db/onepiece.json
+++ b/db/onepiece.json
@@ -1,4 +1,5 @@
 {
+	"Characters":["Luffy", "Zoro", "Nami", "Usopp", "Sanji", "Chopper", "Robin", "Franky", "Brook", "Jinbe", "Legends", "Shibukais", "Yonkos", "Others"],
     "Luffy":[
         "I Am Going To Be The Pirate King.",
         "If You Don't Take Risks, You Can't Create A Future.",

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# Importing modules
+import json
+
+def read_quotations_from_file(path):
+    with open(path, "r") as file:
+        quotations = json.load(file)
+    return quotations


### PR DESCRIPTION
The setup was done to create html pages. But, this can't be used for Android apps properly or we will get the webpage content opening in the app. This is not a good way. 

Modification: Instead of sending data to HTML templates and integrating template, we are sending data(JSON) to endpoint. 
Also, for refactoring.
1. Adding helper script.
2. Remove overheads and extra instructions.